### PR TITLE
Update Control Helm chart to version 0.3.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,52 @@
 All notable changes to this project will be documented in this file.
 
 
+## [0.3.70] - 2026-03-18
+### Helm changes
+
+- Applications versions:
+  - server - 5.156.0
+  - frontend - 5.156.0
+  - realtime - 3.10.0
+  - control-tasks - 2.75.0
+  - widget - v1.87.0
+
+### Improvements / New Features
+
+#### 1. User Tagging Logic in Event Comments (Group Users Support)
+#### 2. Implement Account & Currency Search API with Vector Search Support
+#### 3. Automatic Callback for the Missing Call Participant
+#### 4. autoSubmit timer activation with visibililty changes & maxCount 500
+#### 5. Documentation for Realtime API pages/realtime
+#### 6. API-based Grouping of Events into Hierarchical Folders (Graph-Based, Infinite Nesting) [front-end]
+#### 7. Add In-Product User Guide for Collaborative Code Usage in Smart Forms Editor
+#### 8. Access Requests for Actors and Meetings — Backend Migration
+#### 9. Add push notifications for actor access requests
+#### 10. CDU Refresh logic
+#### 11. Meeting room - user extension
+#### 12. Document MainMenu postMessage navigation and Comments autoScroll
+
+### Bug Fixes
+
+#### 1. Incorrect time displayed in email notification (Due date / Created)
+#### 2. Numeric text value is rounded in Text field
+#### 3. Access request buttons do not disappear after granting permissions
+#### 4. Delay when joining a meeting — no UI feedback after clicking "Join Meeting"
+#### 5. Same Tag Can Be Selected Multiple Times
+#### 6. Invalid visibility value breaks dropdown behavior
+#### 7. Script Import Styles Cache Refresh Issue
+#### 8. Multiselect crashes when entering "[" in the search field
+#### 9. Error when creating a connection – Cannot read properties of undefined (reading 'laId')
+#### 10. Show latest reactions disappears after creating a reply
+#### 11. Error when selecting multiple smart chips in comments
+#### 12. User is redirected to 403 page when changing graph settings or clicking dashboard pin with mixed permissions
+#### 13. Filter Counter Is Not Updated in Real Time
+#### 14. Error Cannot read properties of undefined (reading 'laId') When Moving State with Actors Between Layers
+#### 15. User cannot remove their reaction (signature)
+#### 16. Sign button state is not restored after internet connection is recovered
+#### 17. CDU: Content loop changes issue with definition refs
+
+
 ## [0.3.69] - 2026-02-18
 ### Helm changes
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,24 +3,24 @@ name: control
 description: A Helm chart for Control
 icon: https://sim.simulator.company/static/logo.svg
 type: application
-version: 0.3.69
-appVersion: 5.152.0
+version: 0.3.70
+appVersion: 5.156.0
 
 dependencies:
   - name: server
-    version: 0.3.65
+    version: 0.3.66
     repository: file://charts/server
   - name: frontend
-    version: 0.3.64
+    version: 0.3.65
     repository: file://charts/frontend
   - name: realtime
-    version: 0.3.20
+    version: 0.3.21
     repository: file://charts/realtime
   - name: control-tasks
-    version: 0.1.34
+    version: 0.1.35
     repository: file://charts/control-tasks
   - name: widget
-    version: 0.3.55
+    version: 0.3.56
     repository: file://charts/widget
   - name: ctrl-sim-api
     version: 0.1.2

--- a/charts/control-tasks/Chart.yaml
+++ b/charts/control-tasks/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: control-tasks
 description: A Helm chart for Control Tasks
 type: application
-version: 0.1.34
-appVersion: 2.72.1
+version: 0.1.35
+appVersion: 2.75.0

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: A Helm chart for Control Frontend
 type: application
-version: 0.3.64
-appVersion: 5.152.0
+version: 0.3.65
+appVersion: 5.156.0

--- a/charts/realtime/Chart.yaml
+++ b/charts/realtime/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: realtime
 description: A Helm chart for Control Realtime
 type: application
-version: 0.3.20
-appVersion: 3.9.1
+version: 0.3.21
+appVersion: 3.10.0

--- a/charts/server/Chart.yaml
+++ b/charts/server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: server
 description: A Helm chart for Control Server
 type: application
-version: 0.3.65
-appVersion: 5.152.0
+version: 0.3.66
+appVersion: 5.156.0

--- a/charts/widget/Chart.yaml
+++ b/charts/widget/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: widget
 description: A Helm chart for Control Server
 type: application
-version: 0.3.55
-appVersion: "v1.85.0"
+version: 0.3.56
+appVersion: "v1.87.0"


### PR DESCRIPTION
- Updated root chart version from 0.3.69 to 0.3.70
- Updated appVersion from 5.152.0 to 5.156.0
- Updated server subchart version from 0.3.65 to 0.3.66 (appVersion 5.156.0)
- Updated frontend subchart version from 0.3.64 to 0.3.65 (appVersion 5.156.0)
- Updated realtime subchart version from 0.3.20 to 0.3.21 (appVersion 3.10.0)
- Updated control-tasks subchart version from 0.1.34 to 0.1.35 (appVersion 2.75.0)
- Updated widget subchart version from 0.3.55 to 0.3.56 (appVersion v1.87.0)
- Updated CHANGELOG.md with new release entry