### PR TITLE
Update Control Helm chart to version 0.3.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this project will be documented in this file.
 
 
+## [0.3.71] - 2026-05-27
+### Helm changes
+
+- Applications versions:
+  - server - 5.166.0
+  - frontend - 5.166.0
+  - realtime - 3.12.0
+  - control-tasks - 2.77.0
+  - widget - v1.91.0
+
+### Improvements / New Features
+
+#### 1. Open task actor from Gantt mode
+#### 2. Progress for task actor in Gantt
+#### 3. Add edge title without editing it
+#### 4. Widget: Create reaction with attachments via single API flow
+#### 5. Dashboards: Migrate to Chart.js 4.5.1
+#### 6. Preserve per-file editing history and cursor position in ScriptEditor
+#### 7. Add editing actor title in graph
+
+### Bug Fixes
+
+#### 1. [Simulator] Screen Share Not Syncing Slides for Viewers During Presentation
+#### 2. Actors bag > Accounts > Dashboard: transactions sent today are displayed under incorrect dates
+#### 3. 500 Internal Error occurs when changing owner of actor
+#### 4. Different number of fields displayed in filter and dashboard
+#### 5. Bold text in event creation changes structure
+
+
 ## [0.3.70] - 2026-03-18
 ### Helm changes
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,24 +3,24 @@ name: control
 description: A Helm chart for Control
 icon: https://sim.simulator.company/static/logo.svg
 type: application
-version: 0.3.70
-appVersion: 5.156.0
+version: 0.3.71
+appVersion: 5.166.0
 
 dependencies:
   - name: server
-    version: 0.3.66
+    version: 0.3.67
     repository: file://charts/server
   - name: frontend
-    version: 0.3.65
+    version: 0.3.66
     repository: file://charts/frontend
   - name: realtime
-    version: 0.3.21
+    version: 0.3.22
     repository: file://charts/realtime
   - name: control-tasks
-    version: 0.1.35
+    version: 0.1.36
     repository: file://charts/control-tasks
   - name: widget
-    version: 0.3.56
+    version: 0.3.57
     repository: file://charts/widget
   - name: ctrl-sim-api
     version: 0.1.2
@@ -46,3 +46,11 @@ dependencies:
     version: 0.1.3
     repository: file://charts/claude-code-api
     condition: global.control.claude_code_api.enabled
+  - name: ufs
+    version: 0.1.0
+    repository: file://charts/ufs
+    condition: global.control.ufs.enabled
+  - name: clamav
+    version: 0.1.0
+    repository: file://charts/clamav
+    condition: global.control.clamav.enabled

--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: clamav
+description: A Helm chart for ClamAV antivirus daemon
+type: application
+version: 0.1.0
+appVersion: 1.4.1

--- a/charts/clamav/templates/_helpers.tpl
+++ b/charts/clamav/templates/_helpers.tpl
@@ -1,0 +1,4 @@
+{{- define "clamav.labels" -}}
+app: {{ .Values.global.control.product }}
+tier: {{ .Values.appName }}
+{{- end }}

--- a/charts/clamav/templates/deployment.yaml
+++ b/charts/clamav/templates/deployment.yaml
@@ -1,0 +1,63 @@
+{{- $clamav := .Values.global.control.clamav }}
+{{- if $clamav.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.appName }}
+  labels:
+    {{- include "clamav.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "clamav.labels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "clamav.labels" . | nindent 8 }}
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
+      {{- end }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Values.appName }}
+          image: "{{ .Values.global.imageRegistry }}/hub.docker.com/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - name: clamd
+              containerPort: {{ .Values.appPort }}
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: clamd
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: clamd
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml $clamav.resources | nindent 12 }}
+      {{- with $clamav.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $clamav.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $clamav.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/clamav/templates/service.yaml
+++ b/charts/clamav/templates/service.yaml
@@ -1,0 +1,18 @@
+{{- $clamav := .Values.global.control.clamav }}
+{{- if $clamav.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.appName }}
+  labels:
+    {{- include "clamav.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.appPort }}
+      targetPort: clamd
+      protocol: TCP
+      name: clamd
+  selector:
+    {{- include "clamav.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -1,0 +1,8 @@
+appName: clamav
+appPort: 3310
+
+image:
+  registry: ""
+  repository: clamav/clamav
+  tag: "stable"
+  pullPolicy: IfNotPresent

--- a/charts/claude-code-api/templates/_helpers.tpl
+++ b/charts/claude-code-api/templates/_helpers.tpl
@@ -8,7 +8,8 @@ tier: claude-code-api
 Image url
 */}}
 {{- define "claude-code-api.imageUrl" -}}
-{{ .Values.global.imageRegistry }}/{{ .Values.global.repotype | default "public" }}/{{ .Values.image.repository }}:{{ .Values.global.control.claude_code_api.tag | default .Chart.AppVersion }}
+{{- $repo := ((.Values.global.control.claude_code_api.image).repository) | default (printf "%s/%s" (.Values.global.repotype | default "public") .Values.image.repository) -}}
+{{ .Values.global.imageRegistry }}/{{ $repo }}:{{ .Values.global.control.claude_code_api.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{/*

--- a/charts/control-tasks/Chart.yaml
+++ b/charts/control-tasks/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: control-tasks
 description: A Helm chart for Control Tasks
 type: application
-version: 0.1.35
-appVersion: 2.75.0
+version: 0.1.36
+appVersion: 2.77.0

--- a/charts/ctrl-sim-api/templates/configmap.yaml
+++ b/charts/ctrl-sim-api/templates/configmap.yaml
@@ -137,6 +137,14 @@ data:
       {{- else if eq .Values.global.control.filesStorage.type "efs" }}
       type: fs
       path: {{ .Values.global.control.filesStorage.eventFiles }}
+      {{- else if eq .Values.global.control.filesStorage.type "ufs" }}
+      type: ufs
+      path: {{ .Values.global.control.filesStorage.eventFiles | default "assets/eventFiles" }}
+      ufs:
+        url: {{ .Values.global.control.filesStorage.ufs.url }}
+        bucket: {{ .Values.global.control.filesStorage.ufs.bucket }}
+        async: {{ .Values.global.control.filesStorage.ufs.async | default false }}
+        antivirus: {{ .Values.global.control.filesStorage.ufs.antivirus | default "clamav" }}
       {{- end }}
       {{- else }}
       type: fs

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: A Helm chart for Control Frontend
 type: application
-version: 0.3.65
-appVersion: 5.156.0
+version: 0.3.66
+appVersion: 5.166.0

--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -284,6 +284,11 @@ data:
         proxy_intercept_errors on;
         add_header             Cache-Control max-age=31536000;
         proxy_pass             https://$bucket/$2;
+        {{- else if eq .Values.global.control.filesStorage.type "ufs" }}
+        add_header             Content-Disposition "inline" always;
+        client_max_body_size   {{ include "control.frontend.nginx.client_max_body_size" . }};
+        rewrite                ^/(api|papi)/1\.0/download/(.+)$ /api/v1/download/$2 break;
+        proxy_pass             http://ufs-service:8080;
         {{- end }}
         {{- else }}
         {{ include "control.nginx.add_header" . | nindent 8 }}

--- a/charts/frontend/templates/deployment.yaml
+++ b/charts/frontend/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               subPath: assetlinks.json
             {{- end }}
             {{- if .Values.global.control.filesStorage.type }}
-            {{- if ne .Values.global.control.filesStorage.type "s3" }}
+            {{- if and (ne .Values.global.control.filesStorage.type "s3") (ne .Values.global.control.filesStorage.type "ufs") }}
             - name: {{ .Values.appName }}-attachments
               mountPath: {{ $control_data.filesStorage.eventFiles }}
             {{- end }}

--- a/charts/ingress/templates/ingress-ufs.yaml
+++ b/charts/ingress/templates/ingress-ufs.yaml
@@ -1,0 +1,45 @@
+{{- if and (hasKey .Values.global.control "ufs") (hasKey .Values.global.control.ufs "enabled") .Values.global.control.ufs.enabled (hasKey .Values.global.control.ufs "ufsDomain") .Values.global.control.ufs.ufsDomain -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ include "control.fullname" . }}-ufs
+  labels:
+    {{- include "control.labels" . | nindent 4 }}
+  annotations:
+    {{- include "control.ingressAnnotations" . | nindent 4 }}
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.global.control.ufs.maxBodySize | default "2048m" }}"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ .Values.global.control.ufs.proxyReadTimeout | default "3600" }}"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "{{ .Values.global.control.ufs.proxySendTimeout | default "3600" }}"
+spec:
+  {{- if and .Values.global.control.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.global.control.ingress.className }}
+  {{- end }}
+  {{- if .Values.global.control.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.global.control.ufs.ufsDomain }}
+      secretName: tls-ufs
+  {{- end }}
+  rules:
+    - host: {{ .Values.global.control.ufs.ufsDomain }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: ufs-service
+                port:
+                  number: 8080
+              {{- else }}
+              serviceName: ufs-service
+              servicePort: 8080
+              {{- end }}
+{{- end }}

--- a/charts/realtime/Chart.yaml
+++ b/charts/realtime/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: realtime
 description: A Helm chart for Control Realtime
 type: application
-version: 0.3.21
-appVersion: 3.10.0
+version: 0.3.22
+appVersion: 3.12.0

--- a/charts/server/Chart.yaml
+++ b/charts/server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: server
 description: A Helm chart for Control Server
 type: application
-version: 0.3.66
-appVersion: 5.156.0
+version: 0.3.67
+appVersion: 5.166.0

--- a/charts/server/templates/configmap.yaml
+++ b/charts/server/templates/configmap.yaml
@@ -247,6 +247,14 @@ data:
       {{- end }}
       {{- else if eq .Values.global.control.filesStorage.type "efs" }}
       eventFiles: {{ .Values.global.control.filesStorage.eventFiles }}
+      {{- else if eq .Values.global.control.filesStorage.type "ufs" }}
+      type: ufs
+      eventFiles: {{ .Values.global.control.filesStorage.eventFiles | default "assets/eventFiles" }}
+      ufs:
+        url: {{ .Values.global.control.filesStorage.ufs.url }}
+        bucket: {{ .Values.global.control.filesStorage.ufs.bucket }}
+        async: {{ .Values.global.control.filesStorage.ufs.async | default false }}
+        antivirus: {{ .Values.global.control.filesStorage.ufs.antivirus | default "clamav" }}
       {{- end }}
       {{- else }}
       eventFiles: {{ .Values.global.control.filesStorage.eventFiles }}

--- a/charts/server/templates/deployment.yaml
+++ b/charts/server/templates/deployment.yaml
@@ -98,7 +98,7 @@ spec:
               mountPath: /ebsmnt/conf/control.yml
               subPath: control.yml
             {{- if .Values.global.control.filesStorage.type }}
-            {{- if ne .Values.global.control.filesStorage.type "s3" }}
+            {{- if and (ne .Values.global.control.filesStorage.type "s3") (ne .Values.global.control.filesStorage.type "ufs") }}
             - name: {{ .Values.appName }}-attachments
               mountPath: {{ $control_data.filesStorage.eventFiles }}
             {{- end }}
@@ -122,7 +122,7 @@ spec:
           configMap:
             name: {{ .Values.appName }}-configmap
         {{- if .Values.global.control.filesStorage.type }}
-        {{- if ne .Values.global.control.filesStorage.type "s3" }}
+        {{- if and (ne .Values.global.control.filesStorage.type "s3") (ne .Values.global.control.filesStorage.type "ufs") }}
         {{- if $server_data.persistantVolumeClaimCreate }}
         - name: {{ .Values.appName }}-attachments
           persistentVolumeClaim:

--- a/charts/sim-vector/templates/deployment.yaml
+++ b/charts/sim-vector/templates/deployment.yaml
@@ -77,6 +77,13 @@ spec:
             - name: SIM_VECTOR_NAME
               value: "{{ .Values.global.control.sim_vector.simVectorName }}"
             {{- end }}
+            {{- if .Values.global.control.auth.key }}
+            - name: API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "control.configSecretName" . }}
+                  key: configSaSecretKey
+            {{- end }}
             {{- include "control.container_envs_db" . | nindent 12 }}
           ports:
             - name: http

--- a/charts/ufs/Chart.yaml
+++ b/charts/ufs/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ufs
+description: A Helm chart for UFS (Unified File Service)
+type: application
+version: 0.1.0
+appVersion: 1.0.0

--- a/charts/ufs/templates/_helpers.tpl
+++ b/charts/ufs/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{- define "ufs.labels" -}}
+app.kubernetes.io/name: ufs
+app.kubernetes.io/instance: {{ .Release.Name }}
+tier: ufs
+{{- end }}
+
+{{/*
+Image url
+*/}}
+{{- define "ufs.imageUrl" -}}
+{{- $imageRegistry := .Values.global.control.ufs.imageRegistry | default .Values.global.imageRegistry -}}
+{{- $repotype := .Values.global.control.ufs.repotype | default .Values.global.repotype -}}
+{{ $imageRegistry }}/{{ $repotype }}/{{ .Values.image.repository }}:{{ .Values.global.control.ufs.tag | default .Chart.AppVersion }}
+{{- end }}
+
+{{/*
+Secret name for ufs credentials
+*/}}
+{{- define "ufs.secretName" -}}
+{{- .Release.Name }}-{{ .Values.global.control.ufs.db.secret.name }}
+{{- end }}

--- a/charts/ufs/templates/configmap.yaml
+++ b/charts/ufs/templates/configmap.yaml
@@ -1,0 +1,98 @@
+{{- $ufs_data := .Values.global.control.ufs }}
+{{- if and (hasKey .Values.global.control "ufs") (hasKey .Values.global.control.ufs "enabled") $ufs_data.enabled }}
+{{- $storage := $ufs_data.storage }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.appName }}-configmap
+  labels:
+    {{- include "ufs.labels" . | nindent 4 }}
+data:
+  config.yml: |
+    app:
+      name: ufs
+      url: "https://{{ $ufs_data.ufsDomain | default "" }}"
+      version: "{{ .Chart.AppVersion }}"
+      env: "{{ $ufs_data.env | default "production" }}"
+      {{- if $ufs_data.allowed_buckets }}
+      allowed_buckets:
+        {{- range $ufs_data.allowed_buckets }}
+        - {{ . }}
+        {{- end }}
+      {{- end }}
+
+    server:
+      port: 8080
+      read_timeout: {{ $ufs_data.server.read_timeout | default "30s" }}
+      write_timeout: {{ $ufs_data.server.write_timeout | default "30s" }}
+      idle_timeout: {{ $ufs_data.server.idle_timeout | default "60s" }}
+      shutdown_timeout: {{ $ufs_data.server.shutdown_timeout | default "10s" }}
+      api_secret: "${UFS_API_SECRET}"
+
+    database:
+      host: "${UFS_DB_HOST}"
+      port: {{ $ufs_data.db.secret.data.dbport | default "5432" }}
+      user: "${UFS_DB_USER}"
+      password: "${UFS_DB_PASSWORD}"
+      database: "${UFS_DB_NAME}"
+      max_open_conns: {{ $ufs_data.db.maxOpenConns | default 25 }}
+      max_idle_conns: {{ $ufs_data.db.maxIdleConns | default 5 }}
+      conn_max_lifetime: {{ $ufs_data.db.connMaxLifetime | default "5m" }}
+
+    simulator_database:
+      {{- if .Values.global.db.bouncer }}
+      host: {{ include "pgbouncer.service.name" . }}
+      port: {{ .Values.global.db.bouncer_port }}
+      {{- else }}
+      host: {{ .Values.global.db.secret.data.dbhost }}
+      port: {{ .Values.global.db.secret.data.dbport | default "5432" }}
+      {{- end }}
+      user: {{ .Values.global.db.secret.data.dbuser }}
+      password: {{ .Values.global.db.secret.data.dbpwd }}
+      database: {{ .Values.global.db.secret.data.dbname | default "control" }}
+      max_open_conns: 25
+      max_idle_conns: 5
+      conn_max_lifetime: 5m
+
+    storage:
+      # Configure exactly one backend: s3, seaweedfs, or filesystem.
+      s3:
+        enabled: {{ $storage.s3.enabled | default false }}
+        bucket: {{ $storage.s3.bucket | default "" }}
+        region: {{ $storage.s3.region | default "" }}
+        {{- if $storage.s3.endpoint }}
+        endpoint: "${S3_ENDPOINT}"
+        {{- end }}
+        {{- if $storage.s3.accessKeyId }}
+        access_key_id: "${S3_ACCESS_KEY_ID}"
+        secret_access_key: "${S3_SECRET_ACCESS_KEY}"
+        {{- end }}
+        force_path_style: {{ $storage.s3.forcePathStyle | default false }}
+      seaweedfs:
+        enabled: {{ $storage.seaweedfs.enabled | default false }}
+        endpoint: "${SEAWEEDFS_ENDPOINT}"
+      filesystem:
+        enabled: {{ $storage.filesystem.enabled | default false }}
+        path: {{ $storage.filesystem.path | default "" }}
+
+    antivirus:
+      clamav:
+        enabled: {{ $ufs_data.antivirus.clamav.enabled | default false }}
+        network: {{ $ufs_data.antivirus.clamav.network | default "tcp" }}
+        address: "${UFS_CLAMAV_ADDRESS}"
+      syncapi:
+        enabled: {{ $ufs_data.antivirus.syncapi.enabled | default false }}
+        host: "${COREZOID_SYNC_API}"
+        api_login: "${SYNC_API_LOGIN}"
+        api_secret: "${SYNC_API_SECRET}"
+        company_id: "${SYNC_API_COMPANY_ID}"
+        conv_id: ${SYNC_API_CONV_ID}
+        insecure_skip_verify: {{ $ufs_data.antivirus.syncapi.insecureSkipVerify | default true }}
+      corezoid:
+        enabled: {{ $ufs_data.antivirus.corezoid.enabled | default false }}
+        url: "${ANTIVIRUS_PROCESS_URL}"
+        insecure_skip_verify: {{ $ufs_data.antivirus.corezoid.insecureSkipVerify | default true }}
+
+    log:
+      level: {{ $ufs_data.log_level | default "info" }}
+{{- end }}

--- a/charts/ufs/templates/deployment.yaml
+++ b/charts/ufs/templates/deployment.yaml
@@ -1,0 +1,189 @@
+{{- $global_data := .Values.global }}
+{{- $ufs_data := $global_data.control.ufs }}
+{{- if and (hasKey .Values.global.control "ufs") (hasKey .Values.global.control.ufs "enabled") $ufs_data.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.appName }}-deployment
+  labels:
+    {{- include "ufs.labels" . | nindent 4 }}
+spec:
+  {{- if not $ufs_data.autoscaling.enabled }}
+  replicas: {{ $ufs_data.autoscaling.minReplicas | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ufs.labels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        {{- include "ufs.labels" . | nindent 8 }}
+    spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $pullSecret := $global_data.imagePullSecrets }}
+        - name: {{ $pullSecret }}
+      {{- end }}
+      {{- end }}
+      {{- if $ufs_data.serviceAccount.create }}
+      serviceAccountName: {{ .Values.appName }}-serviceaccount
+      {{- end }}
+      securityContext:
+        {{- toYaml $global_data.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- include "InitWait.postgres" . | nindent 8 }}
+        {{- if $ufs_data.storage.filesystem.enabled }}
+        - name: fix-permissions
+          image: busybox
+          command: ["sh", "-c", "chmod 777 {{ $ufs_data.storage.filesystem.path }}"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: ufs-attachments
+              mountPath: {{ $ufs_data.storage.filesystem.path }}
+        {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml $global_data.securityContext | nindent 12 }}
+          image: {{ include "ufs.imageUrl" . | quote }}
+          imagePullPolicy: {{ $ufs_data.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: UFS_CONFIG
+              value: "/opt/conf/config.yml"
+            - name: UFS_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: apiSecret
+            - name: UFS_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: dbhost
+            - name: UFS_DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: dbport
+            - name: UFS_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: dbuser
+            - name: UFS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: dbpwd
+            - name: UFS_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: dbname
+            - name: UFS_CLAMAV_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: clamavAddress
+            - name: COREZOID_SYNC_API
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: syncapiHost
+            - name: SYNC_API_LOGIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: syncapiLogin
+            - name: SYNC_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: syncapiSecret
+            - name: SYNC_API_COMPANY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: syncapiCompanyId
+            - name: SYNC_API_CONV_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: syncapiConvId
+            - name: ANTIVIRUS_PROCESS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: corezoidUrl
+            - name: S3_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: s3Endpoint
+            - name: S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: s3AccessKeyId
+            - name: S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: s3SecretAccessKey
+            - name: SEAWEEDFS_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ufs.secretName" . }}
+                  key: seaweedfsEndpoint
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /opt/conf
+              readOnly: true
+            {{- if $ufs_data.storage.filesystem.enabled }}
+            - name: ufs-attachments
+              mountPath: {{ $ufs_data.storage.filesystem.path }}
+            {{- end }}
+          resources:
+            {{- toYaml $ufs_data.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Values.appName }}-configmap
+        {{- if $ufs_data.storage.filesystem.enabled }}
+        - name: ufs-attachments
+          persistentVolumeClaim:
+            claimName: {{ $ufs_data.storage.filesystem.persistantVolumeClaimName | default "ufs-pvc" }}
+        {{- end }}
+      {{- with $ufs_data.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $ufs_data.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $ufs_data.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/ufs/templates/monitoring.yaml
+++ b/charts/ufs/templates/monitoring.yaml
@@ -1,0 +1,17 @@
+{{- if and (hasKey .Values.global.control "ufs") (hasKey .Values.global.control.ufs "enabled") .Values.global.control.ufs.enabled .Values.global.serviceMonitor.enabled }}
+apiVersion: {{ include "common.ServiceMonitor.apiVersion" . }}
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.appName }}
+  labels:
+    {{- include "ufs.labels" . | nindent 4 }}
+    {{- include "common.ServiceMonitor.metadata.labes" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "ufs.labels" . | nindent 6 }}
+  endpoints:
+  - path: {{ .Values.prometheusPath | default "/metrics" }}
+    targetPort: 8080
+    interval: {{ .Values.prometheusInterval | default "15s" }}
+{{- end }}

--- a/charts/ufs/templates/pvc.yaml
+++ b/charts/ufs/templates/pvc.yaml
@@ -1,0 +1,20 @@
+{{- $ufs_data := .Values.global.control.ufs }}
+{{- if and (hasKey .Values.global.control "ufs") (hasKey .Values.global.control.ufs "enabled") $ufs_data.enabled }}
+{{- if $ufs_data.storage.filesystem.enabled }}
+{{- if $ufs_data.storage.filesystem.persistantVolumeClaimCreate }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $ufs_data.storage.filesystem.persistantVolumeClaimName | default "ufs-pvc" }}
+  labels:
+    {{- include "ufs.labels" . | nindent 4 }}
+spec:
+  storageClassName: {{ $ufs_data.storage.filesystem.storageClassName | default .Values.global.storageClassName }}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ $ufs_data.storage.filesystem.persistantVolumeClaimSize | default "1Gi" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/ufs/templates/rbac.yaml
+++ b/charts/ufs/templates/rbac.yaml
@@ -1,0 +1,15 @@
+{{- $ufs_data := .Values.global.control.ufs }}
+{{- if and (hasKey .Values.global.control "ufs") (hasKey .Values.global.control.ufs "enabled") $ufs_data.enabled }}
+{{- if $ufs_data.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.appName }}-serviceaccount
+  labels:
+    {{- include "ufs.labels" . | nindent 4 }}
+  {{- with $ufs_data.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/ufs/templates/service.yaml
+++ b/charts/ufs/templates/service.yaml
@@ -1,0 +1,19 @@
+{{- if and (hasKey .Values.global.control "ufs") (hasKey .Values.global.control.ufs "enabled") .Values.global.control.ufs.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.appName }}-service
+  labels:
+    {{- include "ufs.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.global.control.ufs.annotations | nindent 4 }}
+spec:
+  selector:
+    {{- include "ufs.labels" . | nindent 4 }}
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: http
+{{- end }}

--- a/charts/ufs/values.yaml
+++ b/charts/ufs/values.yaml
@@ -1,0 +1,7 @@
+appName: ufs
+prometheusPath: /metrics
+prometheusInterval: 15s
+appPort: 8080
+
+image:
+  repository: ufs

--- a/charts/widget/Chart.yaml
+++ b/charts/widget/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: widget
 description: A Helm chart for Control Server
 type: application
-version: 0.3.56
-appVersion: "v1.87.0"
+version: 0.3.57
+appVersion: "v1.91.0"

--- a/mixins/dashboards/control-dashboard.json
+++ b/mixins/dashboards/control-dashboard.json
@@ -1650,7 +1650,7 @@
             "type": "prometheus",
             "uid": "$datasource"
           },
-          "description": "returns the current number of idle workers",
+          "description": "returns the current number of tasks waiting in the pool's queue",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1728,13 +1728,13 @@
                 "uid": "$datasource"
               },
               "editorMode": "code",
-              "expr": "IdleWorkers{namespace=\"$namespace\"}",
+              "expr": "WaitingTasks{namespace=\"$namespace\"}",
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Tasks IdleWorkers",
+          "title": "Tasks WaitingTasks",
           "type": "timeseries"
         },
         {

--- a/mixins/dashboards/ufs.json
+++ b/mixins/dashboards/ufs.json
@@ -1,0 +1,1698 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "UFS (Unified File Storage) \u2014 HTTP, uploads, downloads, antivirus, quarantine, database",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "Control"
+      ],
+      "targetBlank": false,
+      "title": "Control dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "HTTP",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Request rate by status code (2xx, 4xx, 5xx)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 101,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(ufs_http_requests_total{namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate by Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Request rate grouped by method and path",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 102,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (method, path) (rate(ufs_http_requests_total{namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "{{method}} {{path}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate by Method & Path",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "HTTP request latency percentiles (p50, p95, p99)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 103,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "width": 250
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, method, path) (rate(ufs_http_request_duration_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{method}} {{path}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, method, path) (rate(ufs_http_request_duration_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{method}} {{path}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, method, path) (rate(ufs_http_request_duration_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{method}} {{path}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "HTTP Request Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 200,
+      "panels": [],
+      "title": "Storage \u2014 Uploads & Downloads",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Upload rate by bucket, scan mode, and result (success/failure)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 201,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (bucket, scan_mode, result) (rate(ufs_files_uploaded_total{namespace=\"$namespace\", workspace_id=~\"$workspace_id\"}[$__rate_interval]))",
+          "legendFormat": "{{bucket}} / {{scan_mode}} / {{result}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Files Uploaded Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Upload throughput in bytes per second by bucket",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 202,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (bucket) (rate(ufs_files_uploaded_bytes_total{namespace=\"$namespace\", workspace_id=~\"$workspace_id\"}[$__rate_interval]))",
+          "legendFormat": "{{bucket}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Upload Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "End-to-end upload duration including antivirus scanning (p50, p95, p99)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 203,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, bucket, scan_mode) (rate(ufs_upload_duration_seconds_bucket{namespace=\"$namespace\", workspace_id=~\"$workspace_id\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{bucket}}/{{scan_mode}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, bucket, scan_mode) (rate(ufs_upload_duration_seconds_bucket{namespace=\"$namespace\", workspace_id=~\"$workspace_id\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{bucket}}/{{scan_mode}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, bucket, scan_mode) (rate(ufs_upload_duration_seconds_bucket{namespace=\"$namespace\", workspace_id=~\"$workspace_id\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{bucket}}/{{scan_mode}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Upload Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Download rate by bucket and result",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 204,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (bucket, result) (rate(ufs_files_downloaded_total{namespace=\"$namespace\", workspace_id=~\"$workspace_id\"}[$__rate_interval]))",
+          "legendFormat": "{{bucket}} / {{result}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Files Downloaded Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 300,
+      "panels": [],
+      "title": "Antivirus",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Antivirus scan outcomes by scanner type and result (clean/infected/error)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 301,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (scanner, result) (rate(ufs_antivirus_scans_total{namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "{{scanner}} / {{result}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Antivirus Scan Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Antivirus scan latency by scanner (p50, p95, p99)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 302,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, scanner) (rate(ufs_antivirus_scan_duration_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{scanner}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, scanner) (rate(ufs_antivirus_scan_duration_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{scanner}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, scanner) (rate(ufs_antivirus_scan_duration_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{scanner}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Antivirus Scan Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 400,
+      "panels": [],
+      "title": "Quarantine Worker",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Rate of files processed by the quarantine worker by result",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 44
+      },
+      "id": 401,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (result) (rate(ufs_quarantine_files_processed_total{namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "{{result}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Quarantine Files Processed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Rate of stale processing files requeued back to quarantine",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 44
+      },
+      "id": 402,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "rate(ufs_quarantine_stale_requeued_total{namespace=\"$namespace\"}[$__rate_interval])",
+          "legendFormat": "stale requeued",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Quarantine Stale Requeued",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Async callback outcomes from quarantine worker by result",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 44
+      },
+      "id": 403,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (result) (rate(ufs_quarantine_callbacks_total{namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "{{result}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Quarantine Callbacks",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 500,
+      "panels": [],
+      "title": "Database",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Database query latency by query label (p50, p95, p99)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "id": 501,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, query) (rate(ufs_db_query_duration_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{query}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, query) (rate(ufs_db_query_duration_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{query}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, query) (rate(ufs_db_query_duration_seconds_bucket{namespace=\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{query}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "DB Query Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "PostgreSQL connection pool: open, in-use, and idle connections",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      },
+      "id": 502,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "ufs_db_open_connections{namespace=\"$namespace\"}",
+          "legendFormat": "open",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "ufs_db_in_use_connections{namespace=\"$namespace\"}",
+          "legendFormat": "in-use",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "ufs_db_idle_connections{namespace=\"$namespace\"}",
+          "legendFormat": "idle",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "DB Connection Pool",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "revision": 1,
+  "schemaVersion": 41,
+  "tags": [
+    "ufs",
+    "golang",
+    "Control"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "includeAll": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(ufs_http_requests_total, namespace)",
+        "includeAll": false,
+        "label": "namespace",
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(ufs_http_requests_total, namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(ufs_files_uploaded_total{namespace=\"$namespace\"}, workspace_id)",
+        "includeAll": true,
+        "label": "workspace_id",
+        "multi": true,
+        "name": "workspace_id",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(ufs_files_uploaded_total{namespace=\"$namespace\"}, workspace_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(ufs_http_requests_total{namespace=\"$namespace\"}, instance)",
+        "includeAll": true,
+        "label": "instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(ufs_http_requests_total{namespace=\"$namespace\"}, instance)",
+          "refId": "Prometheus-instance-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "UFS",
+  "uid": "ufs-main",
+  "version": 1,
+  "weekStart": ""
+}

--- a/values.yaml
+++ b/values.yaml
@@ -242,6 +242,12 @@ global:
 #       region: "eu-west-1"
 #       bucket: "mw-dev-control-2-storage" # for AWS S3
 #       efsFileSystemId: fs-0aaa210ad904c3991   # for AWS EFS
+#       type: "ufs" # Universal File Storage
+#       ufs:
+#         url: "https://ufs-pre.simulator.company"
+#         bucket: "mw-pre-control-1-euw1-storage"
+#         async: true   # true for pre (async antivirus + ws callback), false for dev (sync)
+#         antivirus: clamav
     webConfig:
       supportEmail: ''
       maxFileSize: '26214400'
@@ -589,6 +595,115 @@ global:
       tracing:
         enabled: false
         serverAddress: ''
+    ufs:
+      enabled: false
+      ufsDomain: ""
+      maxBodySize: "2048m"
+      proxyReadTimeout: "3600"
+      proxySendTimeout: "3600"
+      pullPolicy: IfNotPresent
+      # tag: ""
+      env: production
+      log_level: info
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      autoscaling:
+        enabled: false
+        minReplicas: 1
+        maxReplicas: 3
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
+      resources:
+        limits:
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+      server:
+        read_timeout: 600s
+        write_timeout: 600s
+        idle_timeout: 120s
+        shutdown_timeout: 10s
+      db:
+        maxOpenConns: 25
+        maxIdleConns: 5
+        connMaxLifetime: 5m
+      redis:
+        db: 0
+      serviceAccount:
+        create: false
+        annotations: {}
+      storage:
+        # Configure exactly one backend: s3, seaweedfs, or filesystem.
+        #
+        # --- Direct S3 (AWS or S3-compatible) ---
+        s3:
+          enabled: true
+          bucket: ""
+          region: ""
+          endpoint: ""          # optional, omit for AWS S3
+          accessKeyId: ""       # optional, omit when using IAM role
+          secretAccessKey: ""   # optional, omit when using IAM role
+          forcePathStyle: false # set true for MinIO / non-AWS
+        # --- SeaweedFS ---
+        seaweedfs:
+          enabled: false
+          endpoint: ""          # Filer HTTP API, e.g. http://seaweedfs-filer:8888
+        # --- Local filesystem (requires PVC) ---
+        filesystem:
+          enabled: false
+          path: "/ebsmnt/attachments"
+          storageClassName: ""          # override global storageClassName, e.g. EFS class for ReadWriteMany
+          persistantVolumeClaimCreate: false
+          persistantVolumeClaimName: "ufs-pvc"
+          persistantVolumeClaimSize: "1Gi"
+      allowed_buckets: []     # whitelist of valid bucket names; remove or leave empty to allow all
+      antivirus:
+        clamav:
+          enabled: true
+          network: tcp
+        syncapi:
+          enabled: false
+          host: ""
+          apiLogin: ""
+          apiSecret: ""
+          companyId: ""
+          convId: ""
+          insecureSkipVerify: true
+        corezoid:
+          enabled: false
+          url: ""
+          insecureSkipVerify: true
+      secret:
+        name: ufs-secret
+        create: true
+        data:
+          dbhost: "postgres"
+          dbport: "5432"
+          dbuser: "dbuser"
+          dbpwd: "dbpwd"
+          dbname: "ufs"
+          apiSecret: ""
+          redisAddr: "redis-master:6379"
+          redisPassword: ""
+          clamavAddress: "clamav:3310"
+    clamav:
+      enabled: false
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: 100m
+          memory: 1Gi
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+
   sa:
     subDomain: "account.corezoid.local"
     config:


### PR DESCRIPTION
- Updated root chart version from 0.3.70 to 0.3.71
- Updated appVersion from 5.156.0 to 5.166.0
- Updated server subchart version from 0.3.66 to 0.3.67 (appVersion 5.166.0)
- Updated frontend subchart version from 0.3.65 to 0.3.66 (appVersion 5.166.0)
- Updated realtime subchart version from 0.3.21 to 0.3.22 (appVersion 3.12.0)
- Updated control-tasks subchart version from 0.1.35 to 0.1.36 (appVersion 2.77.0)
- Updated widget subchart version from 0.3.56 to 0.3.57 (appVersion v1.91.0)
- Added ufs and clamav subcharts (Universal File Storage feature)
- Updated CHANGELOG.md with new release entry