### PR TITLE
Update Control Helm chart to version 0.3.72

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,27 +3,27 @@ name: control
 description: A Helm chart for Control
 icon: https://sim.simulator.company/static/logo.svg
 type: application
-version: 0.3.71
-appVersion: 5.166.0
+version: 0.3.72
+appVersion: 5.168.0
 
 dependencies:
   - name: server
-    version: 0.3.67
+    version: 0.3.68
     repository: file://charts/server
   - name: frontend
-    version: 0.3.66
+    version: 0.3.67
     repository: file://charts/frontend
   - name: realtime
-    version: 0.3.22
+    version: 0.3.23
     repository: file://charts/realtime
   - name: control-tasks
-    version: 0.1.36
+    version: 0.1.37
     repository: file://charts/control-tasks
   - name: widget
-    version: 0.3.57
+    version: 0.3.58
     repository: file://charts/widget
   - name: ctrl-sim-api
-    version: 0.1.2
+    version: 0.1.3
     repository: file://charts/ctrl-sim-api
     condition: global.control.ctrl_sim_api.enabled
   - name: sim-vector
@@ -47,7 +47,7 @@ dependencies:
     repository: file://charts/claude-code-api
     condition: global.control.claude_code_api.enabled
   - name: ufs
-    version: 0.1.0
+    version: 0.1.1
     repository: file://charts/ufs
     condition: global.control.ufs.enabled
   - name: clamav

--- a/charts/claude-code-api/templates/deployment.yaml
+++ b/charts/claude-code-api/templates/deployment.yaml
@@ -42,6 +42,14 @@ spec:
               value: "0.0.0.0"
             - name: SERVER_PORT
               value: "8000"
+            - name: MCP_SERVER_PORT
+              value: "{{ $claude_code_api_data.mcp_server_port | default 8001 }}"
+            - name: MCP_ACCOUNT_URL
+              value: "{{ $claude_code_api_data.mcp_account_url | default "https://account.dev.corezoid.com" }}"
+            - name: MCP_SIMULATOR_URL
+              value: "{{ $claude_code_api_data.mcp_simulator_url | default "https://sim-dev.simulator.company" }}"
+            - name: MCP_RESOURCE_URL
+              value: "{{ $claude_code_api_data.mcp_resource_url | default "https://mcp-dev.simulator.company" }}"
             - name: DB_CLAUDECODE_NAME
               value: "{{ $claude_code_api_data.db.secret.data.dbname | default ($claude_code_api_data.dbname | default "claude_code") }}"
             - name: DATABASE_TIMEZONE
@@ -50,6 +58,10 @@ spec:
               value: "{{ $claude_code_api_data.log_level }}"
             - name: LOG_FORMAT
               value: "{{ $claude_code_api_data.log_format | default "json" }}"
+            - name: LITELLM_SPEND_KEY
+              value: "{{ $claude_code_api_data.litellm_spend_key | default "sk-1234" }}"
+            - name: LITELLM_SPEND_PULL_BUDGET_MINUTES
+              value: "{{ $claude_code_api_data.litellm_spend_pull_budget_minutes | default 30 }}"
             {{- if and (hasKey $claude_code_api_data "auth_api_key") $claude_code_api_data.auth_api_key }}
             - name: AUTH_API_KEY
               value: "{{ $claude_code_api_data.auth_api_key }}"
@@ -62,10 +74,23 @@ spec:
             - name: GIT_TOKEN
               value: "{{ $claude_code_api_data.git_token }}"
             {{- end }}
+            {{- if and (hasKey $claude_code_api_data "otel") $claude_code_api_data.otel.enabled }}
+            - name: TELEMETRY_ENABLED
+              value: "true"
+            - name: OTEL_TRACES_ENABLED
+              value: "true"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "{{ $claude_code_api_data.otel.endpoint }}"
+            - name: OTEL_SERVICE_NAME
+              value: "{{ $claude_code_api_data.otel.service_name | default "cc-api" }}"
+            {{- end }}
             {{- include "claude-code-api.container_envs_db" . | nindent 12 }}
           ports:
             - name: http
               containerPort: 8000
+              protocol: TCP
+            - name: mcp
+              containerPort: {{ $claude_code_api_data.mcp_server_port | default 8001 }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/claude-code-api/templates/service.yaml
+++ b/charts/claude-code-api/templates/service.yaml
@@ -16,4 +16,8 @@ spec:
       targetPort: 8000
       protocol: TCP
       name: http
+    - port: {{ .Values.global.control.claude_code_api.mcp_server_port | default 8001 }}
+      targetPort: {{ .Values.global.control.claude_code_api.mcp_server_port | default 8001 }}
+      protocol: TCP
+      name: mcp
 {{- end }}

--- a/charts/claude-code-api/values.yaml
+++ b/charts/claude-code-api/values.yaml
@@ -5,3 +5,9 @@ prometheusInterval: 15s
 appReadinessHttpPort: 8000
 image:
   repository: claude-code-api
+# -- OpenTelemetry tracing (OTLP/HTTP).
+# When enabled, injects TELEMETRY_ENABLED, OTEL_TRACES_ENABLED, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_SERVICE_NAME.
+# otel:
+#   enabled: false
+#   endpoint: "http://observability-tempo-distributor.observability:4318/v1/traces"
+#   service_name: "cc-api"

--- a/charts/control-tasks/Chart.yaml
+++ b/charts/control-tasks/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: control-tasks
 description: A Helm chart for Control Tasks
 type: application
-version: 0.1.36
-appVersion: 2.77.0
+version: 0.1.37
+appVersion: 2.79.0

--- a/charts/ctrl-sim-api/Chart.yaml
+++ b/charts/ctrl-sim-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ctrl-sim-api
 description: A Helm chart for Control Simulator API
 type: application
-version: 0.1.2
-appVersion: 0.0.21
+version: 0.1.3
+appVersion: 0.3.0

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: A Helm chart for Control Frontend
 type: application
-version: 0.3.66
-appVersion: 5.166.0
+version: 0.3.67
+appVersion: 5.168.2

--- a/charts/ingress/templates/ingress-claude-code-api-mcp.yaml
+++ b/charts/ingress/templates/ingress-claude-code-api-mcp.yaml
@@ -1,0 +1,45 @@
+{{- if and (hasKey .Values.global.control "claude_code_api") (hasKey .Values.global.control.claude_code_api "enabled") .Values.global.control.claude_code_api.enabled (hasKey .Values.global.control.claude_code_api "mcpDomain") .Values.global.control.claude_code_api.mcpDomain -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ include "control.fullname" . }}-mcp
+  labels:
+    {{- include "control.labels" . | nindent 4 }}
+  annotations:
+    {{- include "control.ingressAnnotations" . | nindent 4 }}
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+spec:
+  {{- if and .Values.global.control.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.global.control.ingress.className }}
+  {{- end }}
+  {{- if .Values.global.control.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.global.control.claude_code_api.mcpDomain }}
+      secretName: tls-claude-code-api-mcp
+  {{- end }}
+  rules:
+    - host: {{ .Values.global.control.claude_code_api.mcpDomain }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: claude-code-api-service
+                port:
+                  number: {{ .Values.global.control.claude_code_api.mcp_server_port | default 8001 }}
+              {{- else }}
+              serviceName: claude-code-api-service
+              servicePort: {{ .Values.global.control.claude_code_api.mcp_server_port | default 8001 }}
+              {{- end }}
+{{- end }}

--- a/charts/realtime/Chart.yaml
+++ b/charts/realtime/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: realtime
 description: A Helm chart for Control Realtime
 type: application
-version: 0.3.22
-appVersion: 3.12.0
+version: 0.3.23
+appVersion: 3.13.0

--- a/charts/server/Chart.yaml
+++ b/charts/server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: server
 description: A Helm chart for Control Server
 type: application
-version: 0.3.67
-appVersion: 5.166.0
+version: 0.3.68
+appVersion: 5.168.0

--- a/charts/server/templates/configmap.yaml
+++ b/charts/server/templates/configmap.yaml
@@ -340,4 +340,13 @@ data:
       apiKey: {{ .apiKey }}
       voice: {{ .voice }}
     {{- end }}
+    {{- if and (hasKey $control_server_config "aiAgent") $control_server_config.aiAgent.enabled }}
+    aiAgent:
+      enabled: {{ $control_server_config.aiAgent.enabled }}
+      apiUrl: {{ $control_server_config.aiAgent.apiUrl }}
+      mcp: {{ $control_server_config.aiAgent.mcp }}
+      ttlSeconds: {{ $control_server_config.aiAgent.ttlSeconds | default 1800 }}
+      timeoutMs: {{ $control_server_config.aiAgent.timeoutMs | default 600000 }}
+      stream: {{ $control_server_config.aiAgent.stream | default true }}
+    {{- end }}
     {{- end }}

--- a/charts/ufs/Chart.yaml
+++ b/charts/ufs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ufs
 description: A Helm chart for UFS (Unified File Service)
 type: application
-version: 0.1.0
-appVersion: 1.0.0
+version: 0.1.1
+appVersion: 1.0.4

--- a/charts/ufs/templates/configmap.yaml
+++ b/charts/ufs/templates/configmap.yaml
@@ -93,6 +93,11 @@ data:
         url: "${ANTIVIRUS_PROCESS_URL}"
         insecure_skip_verify: {{ $ufs_data.antivirus.corezoid.insecureSkipVerify | default true }}
 
+    worker:
+      # Skip TLS cert verification for async_url callbacks sent by the quarantine
+      # worker (use when the caller endpoint serves a self-signed cert).
+      callback_insecure_skip_verify: {{ $ufs_data.worker.callbackInsecureSkipVerify | default false }}
+
     log:
       level: {{ $ufs_data.log_level | default "info" }}
 {{- end }}

--- a/charts/widget/Chart.yaml
+++ b/charts/widget/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: widget
 description: A Helm chart for Control Server
 type: application
-version: 0.3.57
-appVersion: "v1.91.0"
+version: 0.3.58
+appVersion: "v1.93.0"

--- a/values.yaml
+++ b/values.yaml
@@ -679,6 +679,11 @@ global:
           enabled: false
           url: ""
           insecureSkipVerify: true
+      worker:
+        # Skip TLS cert verification for async_url callbacks sent by the
+        # quarantine worker (set true when the caller endpoint uses a
+        # self-signed cert).
+        callbackInsecureSkipVerify: false
       secret:
         name: ufs-secret
         create: true


### PR DESCRIPTION
- Updated root chart version from 0.3.71 to 0.3.72
- Updated appVersion from 5.166.0 to 5.168.0
- Updated server subchart version from 0.3.67 to 0.3.68 (appVersion 5.168.0)
- Updated frontend subchart version from 0.3.66 to 0.3.67 (appVersion 5.168.2)
- Updated realtime subchart version from 0.3.22 to 0.3.23 (appVersion 3.13.0)
- Updated control-tasks subchart version from 0.1.36 to 0.1.37 (appVersion 2.79.0)
- Updated widget subchart version from 0.3.57 to 0.3.58 (appVersion v1.93.0)
- Updated ufs subchart version from 0.1.0 to 0.1.1 (appVersion 1.0.4)
- Updated ctrl-sim-api subchart version from 0.1.2 to 0.1.3 (appVersion 0.3.0)