### PR TITLE
Update Control Helm chart to version 0.3.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,45 @@
 All notable changes to this project will be documented in this file.
 
 
+## [0.3.73] - 2026-07-01
+### Helm changes
+
+- Applications versions:
+  - server - 5.171.0
+  - frontend - 5.171.0
+  - realtime - 3.14.0
+  - control-tasks - 2.81.0
+  - widget - v1.96.0
+  - claude-code-api - 1.3.0
+- Dependencies:
+  - account - 3.29.3 (minimum required Account/SingleSpace version)
+
+### Improvements / New Features
+
+#### 1. AI & MCP Integration
+#### 2. Smart Forms Lifecycle
+#### 3. Graph & Visual Modeling
+#### 4. Public API Expansion
+#### 5. Data Export Tools
+#### 6. Dashboards & Charts
+#### 7. Meetings & Collaboration
+#### 8. Content Editing Experience
+#### 9. Attachments & Actor Panels
+#### 10. Performance & Scalability
+#### 11. Platform Observability
+#### 12. UX & Navigation
+
+### Bug Fixes
+
+#### 1. Access & Permissions
+#### 2. Graph & Actor Operations
+#### 3. Dashboards & Charts
+#### 4. Meetings
+#### 5. Text Editor & Formatting
+#### 6. Tags, Filters & Events
+#### 7. Backend & API Stability
+
+
 ## [0.3.71] - 2026-05-27
 ### Helm changes
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,24 +3,24 @@ name: control
 description: A Helm chart for Control
 icon: https://sim.simulator.company/static/logo.svg
 type: application
-version: 0.3.72
-appVersion: 5.168.0
+version: 0.3.73
+appVersion: 5.171.0
 
 dependencies:
   - name: server
-    version: 0.3.68
+    version: 0.3.69
     repository: file://charts/server
   - name: frontend
-    version: 0.3.67
+    version: 0.3.68
     repository: file://charts/frontend
   - name: realtime
-    version: 0.3.23
+    version: 0.3.24
     repository: file://charts/realtime
   - name: control-tasks
-    version: 0.1.37
+    version: 0.1.38
     repository: file://charts/control-tasks
   - name: widget
-    version: 0.3.58
+    version: 0.3.59
     repository: file://charts/widget
   - name: ctrl-sim-api
     version: 0.1.3
@@ -43,7 +43,7 @@ dependencies:
     repository: file://charts/sim-vector-diskann
     condition: global.control.sim_vector_diskann.enabled
   - name: claude-code-api
-    version: 0.1.3
+    version: 0.1.4
     repository: file://charts/claude-code-api
     condition: global.control.claude_code_api.enabled
   - name: ufs

--- a/charts/claude-code-api/Chart.yaml
+++ b/charts/claude-code-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: claude-code-api
 description: A Helm chart for Claude Code API
 type: application
-version: 0.1.3
-appVersion: 1.0.15
+version: 0.1.4
+appVersion: 1.3.0

--- a/charts/control-tasks/Chart.yaml
+++ b/charts/control-tasks/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: control-tasks
 description: A Helm chart for Control Tasks
 type: application
-version: 0.1.37
-appVersion: 2.79.0
+version: 0.1.38
+appVersion: 2.81.0

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: A Helm chart for Control Frontend
 type: application
-version: 0.3.67
-appVersion: 5.168.2
+version: 0.3.68
+appVersion: 5.171.0

--- a/charts/frontend/templates/configmap.yaml
+++ b/charts/frontend/templates/configmap.yaml
@@ -64,6 +64,13 @@ data:
       "apmHost": ""
     }
   control_{{ .Values.appName }}.conf: |
+    {{- if and .Values.global.control.filesStorage.type (eq .Values.global.control.filesStorage.type "ufs") }}
+    # CE-15636: never inline actively-executable content served from UFS downloads
+    map $upstream_http_content_type $ufs_download_content_disposition {
+        default "inline";
+        "~*^(text/html|application/xhtml\+xml|application/xml|text/xml|application/javascript|image/svg\+xml)" "attachment";
+    }
+    {{- end }}
     {{ if .Values.global.control.apiOld -}}
     {{- if .Values.global.control.apiOld.enabled -}}
     server {
@@ -285,7 +292,8 @@ data:
         add_header             Cache-Control max-age=31536000;
         proxy_pass             https://$bucket/$2;
         {{- else if eq .Values.global.control.filesStorage.type "ufs" }}
-        add_header             Content-Disposition "inline" always;
+        add_header             X-Content-Type-Options "nosniff" always;
+        add_header             Content-Disposition $ufs_download_content_disposition always;
         client_max_body_size   {{ include "control.frontend.nginx.client_max_body_size" . }};
         rewrite                ^/(api|papi)/1\.0/download/(.+)$ /api/v1/download/$2 break;
         proxy_pass             http://ufs-service:8080;

--- a/charts/realtime/Chart.yaml
+++ b/charts/realtime/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: realtime
 description: A Helm chart for Control Realtime
 type: application
-version: 0.3.23
-appVersion: 3.13.0
+version: 0.3.24
+appVersion: 3.14.0

--- a/charts/server/Chart.yaml
+++ b/charts/server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: server
 description: A Helm chart for Control Server
 type: application
-version: 0.3.68
-appVersion: 5.168.0
+version: 0.3.69
+appVersion: 5.171.0

--- a/charts/widget/Chart.yaml
+++ b/charts/widget/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: widget
 description: A Helm chart for Control Server
 type: application
-version: 0.3.58
-appVersion: "v1.93.0"
+version: 0.3.59
+appVersion: "v1.96.0"

--- a/values.yaml
+++ b/values.yaml
@@ -708,6 +708,49 @@ global:
       nodeSelector: {}
       tolerations: []
       affinity: {}
+    claude_code_api:
+      enabled: false
+      image:
+        repository: ""
+      pullPolicy: Always
+      # Overrides the image tag whose default is the claude-code-api chart appVersion.
+      # tag: ""
+      claudeCodeApiDomain: ""
+      mcpDomain: ""
+      mcp_server_port: 8001
+      mcp_account_url: ""
+      mcp_simulator_url: ""
+      mcp_resource_url: ""
+      log_level: info
+      log_format: json
+      litellm_spend_key: ""
+      litellm_spend_pull_budget_minutes: 30
+      # auth_api_key: ""
+      # tls: true
+      # git_token: ""
+      otel:
+        enabled: false
+        endpoint: ""
+        service_name: "cc-api"
+      db_timezone: UTC
+      db:
+        secret:
+          create: true
+          name: "claude-code-api-postgresql-secret"
+          data:
+            dbhost: "postgres"
+            dbport: "5432"
+            dbuser: "dbuser"
+            dbpwd: "dbpwd"
+            dbname: "claude_code"
+      autoscaling:
+        enabled: false
+        minReplicas: 1
+        maxReplicas: 3
+      resources: {}
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
 
   sa:
     subDomain: "account.corezoid.local"


### PR DESCRIPTION
- Updated root chart version from 0.3.72 to 0.3.73
- Updated appVersion from 5.168.0 to 5.171.0
- Updated server subchart version from 0.3.68 to 0.3.69 (appVersion 5.171.0)
- Updated frontend subchart version from 0.3.67 to 0.3.68 (appVersion 5.171.0)
- Updated realtime subchart version from 0.3.23 to 0.3.24 (appVersion 3.14.0)
- Updated control-tasks subchart version from 0.1.37 to 0.1.38 (appVersion 2.81.0)
- Updated widget subchart version from 0.3.58 to 0.3.59 (appVersion v1.96.0)
- Updated claude-code-api subchart version from 0.1.3 to 0.1.4 (appVersion 1.3.0)
- Added global.control.claude_code_api defaults block to values.yaml
- Includes CE-15636 UFS download Content-Disposition hardening
- Updated CHANGELOG.md with new release entry (requires account >= 3.29.3)